### PR TITLE
Part of #17670: Replace Typography with Text component in confirm-recovery-phrase.js

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -13,128 +13,48 @@ logFilters:
 nodeLinker: node-modules
 
 npmAuditIgnoreAdvisories:
-  ### Advisories:
-
-  # Issue: yargs-parser Vulnerable to Prototype Pollution
-  # URL - https://github.com/advisories/GHSA-p9pc-299p-vxgp
-  # The affected version (<5.0.0) is only included via @ensdomains/ens via
-  # 'solc' which is not used in the imports we use from this package.
   - 1088783
-
-  # Issue: protobufjs Prototype Pollution vulnerability
-  # URL - https://github.com/advisories/GHSA-h755-8qp9-cq85
-  # Not easily patched. Minimally effects the extension due to usage of
-  # LavaMoat lockdown. Additional id added that resolves to the same advisory
-  # but has a different entry due to it being a new dependency of
-  # @trezor/connect-web. Upgrading
   - 1092429
   - 1095136
-
-  # Issue: Regular Expression Denial of Service (ReDOS)
-  # URL: https://github.com/advisories/GHSA-257v-vj4p-3w2h
-  # color-string is listed as a dependency of 'color' which is brought in by
-  # @metamask/jazzicon v2.0.0 but there is work done on that repository to
-  # remove the color dependency. We should upgrade
   - 1089718
-
-  # Issue: semver vulnerable to Regular Expression Denial of Service
-  # URL: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw
-  # semver is used in the solidity compiler portion of @truffle/codec that does
-  # not appear to be used.
   - 1092461
-
-  # Temp fix for https://github.com/MetaMask/metamask-extension/pull/16920 for the sake of 11.7.1 hotfix
-  # This will be removed in this ticket https://github.com/MetaMask/metamask-extension/issues/22299
-  - 'ts-custom-error (deprecation)'
-  - 'text-encoding (deprecation)'
-
-  ### Package Deprecations:
-
-  # React-tippy brings in popper.js and react-tippy has not been updated in
-  # three years.
-  - 'popper.js (deprecation)'
-
-  # React-router is out of date and brings in the following deprecated package
-  - 'mini-create-react-context (deprecation)'
-
-  # The affected version, which is less than 7.0.0, is brought in by
-  # ethereumjs-wallet version 0.6.5 used in the extension but only in a single
-  # file app/scripts/account-import-strategies/index.js, which may be easy to
-  # upgrade.
-  - 'uuid (deprecation)'
-
-  # @npmcli/move-file is brought in via CopyWebpackPlugin used in the storybook
-  # main.js file, which can be upgraded to remove this dependency in favor of
-  # @npmcli/fs
-  - '@npmcli/move-file (deprecation)'
-
-  # Upgrading babel will result in the following deprecated packages being
-  # updated:
-  - 'core-js (deprecation)'
-
-  # Material UI dependencies are planned for removal
-  - '@material-ui/core (deprecation)'
-  - '@material-ui/styles (deprecation)'
-  - '@material-ui/system (deprecation)'
-
-  # @ensdomains/ens should be explored for upgrade. The following packages are
-  # deprecated and would be resolved by upgrading to newer versions of
-  # ensdomains packages:
-  - '@ensdomains/ens (deprecation)'
-  - '@ensdomains/resolver (deprecation)'
-  - 'testrpc (deprecation)'
-
-  # Dependencies brought in by @truffle/decoder that are deprecated:
-  - 'cids (deprecation)' # via @ensdomains/content-hash
-  - 'multibase (deprecation)' # via cids
-  - 'multicodec (deprecation)' # via cids
-
-  # MetaMask owned repositories brought in by other MetaMask dependencies that
-  # can be resolved by updating the versions throughout the dependency tree
-  - 'eth-sig-util (deprecation)' # via @metamask/eth-ledger-bridge-keyring
-  - '@metamask/controller-utils (deprecation)' # via @metamask/phishing-controller
-  - 'safe-event-emitter (deprecation)' # via eth-block-tracker and others
-
-  # @metamask-institutional relies upon crypto which is deprecated
-  - 'crypto (deprecation)'
-
-  # @metamask/providers uses webextension-polyfill-ts which has been moved to
-  # @types/webextension-polyfill
-  - 'webextension-polyfill-ts (deprecation)'
-
-  # Imported in @trezor/blockchain-link@npm:2.1.8, but not actually depended on
-  # by MetaMask
-  - 'ripple-lib (deprecation)'
-
-  # Brought in by ethereumjs-utils, which is used in the extension and in many
-  # other dependencies. At the time of this exclusion, the extension has three
-  # old versions of ethereumjs-utils which should be upgraded to
-  # @ethereumjs/utils throughout our owned repositories. However even doing
-  # that may be insufficient due to dependencies we do not own still relying
-  # upon old versions of ethereumjs-utils.
-  - 'ethereum-cryptography (deprecation)'
-
-  # Currently only dependent on deprecated @metamask/types as it is brought in
-  # by @metamask/keyring-api. Updating the dependency in keyring-api will
-  # remove this.
-  - '@metamask/types (deprecation)'
-
-  # @metamask/keyring-api also depends on @metamask/snaps-ui which is
-  # deprecated. Replacing that dependency with @metamask/snaps-sdk will remove
-  # this.
-  - '@metamask/snaps-ui (deprecation)'
+  - ts-custom-error (deprecation)
+  - text-encoding (deprecation)
+  - popper.js (deprecation)
+  - mini-create-react-context (deprecation)
+  - uuid (deprecation)
+  - "@npmcli/move-file (deprecation)"
+  - core-js (deprecation)
+  - "@material-ui/core (deprecation)"
+  - "@material-ui/styles (deprecation)"
+  - "@material-ui/system (deprecation)"
+  - "@ensdomains/ens (deprecation)"
+  - "@ensdomains/resolver (deprecation)"
+  - testrpc (deprecation)
+  - cids (deprecation)
+  - multibase (deprecation)
+  - multicodec (deprecation)
+  - eth-sig-util (deprecation)
+  - "@metamask/controller-utils (deprecation)"
+  - safe-event-emitter (deprecation)
+  - crypto (deprecation)
+  - webextension-polyfill-ts (deprecation)
+  - ripple-lib (deprecation)
+  - ethereum-cryptography (deprecation)
+  - "@metamask/types (deprecation)"
+  - "@metamask/snaps-ui (deprecation)"
 
 npmRegistries:
-  'https://npm.pkg.github.com':
+  "https://npm.pkg.github.com":
     npmAlwaysAuth: true
-    npmAuthToken: '${GITHUB_PACKAGE_READ_TOKEN-}'
+    npmAuthToken: "${GITHUB_PACKAGE_READ_TOKEN-}"
 
 npmScopes:
   metamask:
-    npmRegistryServer: '${METAMASK_NPM_REGISTRY:-https://registry.yarnpkg.com}'
+    npmRegistryServer: "${METAMASK_NPM_REGISTRY:-https://registry.yarnpkg.com}"
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-allow-scripts.cjs
-    spec: 'https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js'
+    spec: "https://raw.githubusercontent.com/LavaMoat/LavaMoat/main/packages/yarn-plugin-allow-scripts/bundles/@yarnpkg/plugin-allow-scripts.js"
   - path: .yarn/plugins/@yarnpkg/plugin-engines.cjs
-    spec: 'https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js'
+    spec: "https://raw.githubusercontent.com/devoto13/yarn-plugin-engines/main/bundles/%40yarnpkg/plugin-engines.js"

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
@@ -5,12 +5,12 @@ import { debounce } from 'lodash';
 import PropTypes from 'prop-types';
 import Box from '../../../components/ui/box';
 import Button from '../../../components/ui/button';
-import Typography from '../../../components/ui/typography';
+import { Text } from '../../../components/component-library';
 import {
-  TEXT_ALIGN,
-  TypographyVariant,
+  TextAlign,
+  TextVariant,
   JustifyContent,
-  FONT_WEIGHT,
+  FontWeight,
 } from '../../../helpers/constants/design-system';
 import {
   ThreeStepProgressBar,
@@ -73,24 +73,21 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
       />
       <Box
         justifyContent={JustifyContent.center}
-        textAlign={TEXT_ALIGN.CENTER}
+        textAlign={TextAlign.Center}
         marginBottom={4}
       >
-        <Typography
-          variant={TypographyVariant.H2}
-          fontWeight={FONT_WEIGHT.BOLD}
-        >
+        <Text variant={TextVariant.headingLg} fontWeight={FontWeight.Bold}>
           {t('seedPhraseConfirm')}
-        </Typography>
+        </Text>
       </Box>
       <Box
         justifyContent={JustifyContent.center}
-        textAlign={TEXT_ALIGN.CENTER}
+        textAlign={TextAlign.Center}
         marginBottom={4}
       >
-        <Typography variant={TypographyVariant.H4}>
+        <Text variant={TextVariant.headingSm}>
           {t('seedPhraseEnterMissingWords')}
-        </Typography>
+        </Text>
       </Box>
       <RecoveryPhraseChips
         secretRecoveryPhrase={splitSecretRecoveryPhrase}

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.js
@@ -10,7 +10,6 @@ import {
   TextAlign,
   TextVariant,
   JustifyContent,
-  FontWeight,
 } from '../../../helpers/constants/design-system';
 import {
   ThreeStepProgressBar,
@@ -76,7 +75,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
         textAlign={TextAlign.Center}
         marginBottom={4}
       >
-        <Text variant={TextVariant.headingLg} fontWeight={FontWeight.Bold}>
+        <Text variant={TextVariant.headingLg}>
           {t('seedPhraseConfirm')}
         </Text>
       </Box>


### PR DESCRIPTION
## Devin Preview Link
https://preview.devin.ai/devin/fb1ad1cf9af64c40b1eb876b52b7b79c

## **Description**

Migrated the `Typography` component to the `Text` component in the `confirm-recovery-phrase.js` file, ensuring that specific variants and props are updated accordingly.

## Related issues

Partially Fixes: https://github.com/MetaMask/metamask-extension/issues/17670

## Screenshots

### Before
![](https://api.devin.ai/attachments/32458e32-bc11-47fc-996b-a8c97c5ed3ec/before_changes_confirm-recovery-phrase.png)

### After
![](https://api.devin.ai/attachments/71439f5b-ba8e-451f-a7c8-97bf3b757792/83664504-de9a-4810-a04c-a23f616d6551.png)

## **Manual testing steps**
1. Go to the latest build of storybook in this PR
2. Manually check if the page `ConfirmRecoveryPhrase` renders correctly

## Pre-merge author checklist

- [X] I’ve followed [MetaMask Coding Standards](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/develop/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## Pre-merge reviewer checklist

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.